### PR TITLE
Release client resources if it is initialized twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 * Describe deprecated APIs in this version
 -->
 
+## [0.3.5] - 2022-04-29
+
+#### Fixed:
+* If the init method is called twice in a row, the second call should cancel the previous polling process.
+
 ## [0.3.3] - 2022-04-28
 
 * Added MIT license

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import EppoClient, { IEppoClient } from './eppo-client';
 import { IExperimentConfiguration } from './experiment/experiment-configuration';
 import ExperimentConfigurationRequestor from './experiment/experiment-configuration-requestor';
 import HttpClient from './http-client';
-import initPoller from './poller';
+import initPoller, { IPoller } from './poller';
 import { sdkName, sdkVersion } from './sdk-data';
 import { validateNotBlank } from './validation';
 
@@ -34,6 +34,8 @@ export interface IClientConfig {
 }
 
 export { IEppoClient } from './eppo-client';
+
+let poller: IPoller = null;
 
 /**
  * Initializes the Eppo client with configuration parameters.
@@ -60,7 +62,11 @@ export function init(config: IClientConfig): IEppoClient {
     configurationStore,
     httpClient,
   );
-  const poller = initPoller(
+  if (poller) {
+    // if a client was already initialized, stop the polling process from the previous init call
+    poller.stop();
+  }
+  poller = initPoller(
     POLL_INTERVAL_MILLIS,
     JITTER_MILLIS,
     configurationRequestor.fetchAndStoreConfigurations.bind(configurationRequestor),

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -1,4 +1,4 @@
-interface IPoller {
+export interface IPoller {
   start: () => Promise<void>;
   stop: () => void;
 }


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

The `init` method is only meant to be called once during the application lifecycle. If the developer calls it twice in a row, that should not create duplicate polling processes; the second call should stop the polling of the previous call.

## Description
[//]: # (Describe your changes in detail)

If the init method is called a second time, stop the polling process from the previous call before re-initializing the poller.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

In a demo app, called the `init` method 3 times in a row. Wait 5 minutes. Verify the client only polls once after the 5 minute poll interval.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
