### PR TITLE
Rename flag -> experiment_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 * Describe deprecated APIs in this version
 -->
 
+## [0.3.6] - 2022-05-03
+
+#### Changed:
+* Renamed the `flag` parameter of the assignment function to `experimentKey`
+
 ## [0.3.5] - 2022-04-29
 
 #### Fixed:

--- a/docs/node-server-sdk.ieppoclient.getassignment.md
+++ b/docs/node-server-sdk.ieppoclient.getassignment.md
@@ -9,7 +9,7 @@ Maps a subject to a variation for a given experiment.
 <b>Signature:</b>
 
 ```typescript
-getAssignment(subject: string, flag: string): string;
+getAssignment(subject: string, experimentKey: string): string;
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ getAssignment(subject: string, flag: string): string;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  subject | string | an entity ID, e.g. userId |
-|  flag | string | experiment identifier |
+|  experimentKey | string | experiment identifier |
 
 <b>Returns:</b>
 

--- a/docs/node-server-sdk.ieppoclient.md
+++ b/docs/node-server-sdk.ieppoclient.md
@@ -22,5 +22,5 @@ export interface IEppoClient
 
 |  Method | Description |
 |  --- | --- |
-|  [getAssignment(subject, flag)](./node-server-sdk.ieppoclient.getassignment.md) | Maps a subject to a variation for a given experiment. |
+|  [getAssignment(subject, experimentKey)](./node-server-sdk.ieppoclient.getassignment.md) | Maps a subject to a variation for a given experiment. |
 

--- a/node-server-sdk.api.md
+++ b/node-server-sdk.api.md
@@ -12,7 +12,7 @@ export interface IClientConfig {
 
 // @public
 export interface IEppoClient {
-    getAssignment(subject: string, flag: string): string;
+    getAssignment(subject: string, experimentKey: string): string;
     waitForInitialization: () => Promise<void>;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [

--- a/src/eppo-client.ts
+++ b/src/eppo-client.ts
@@ -12,11 +12,11 @@ export interface IEppoClient {
    * Maps a subject to a variation for a given experiment.
    *
    * @param subject an entity ID, e.g. userId
-   * @param flag experiment identifier
+   * @param experimentKey experiment identifier
    * @returns a variation value if the subject is part of the experiment sample, otherwise null
    * @public
    */
-  getAssignment(subject: string, flag: string): string;
+  getAssignment(subject: string, experimentKey: string): string;
 
   /**
    * Returns a Promise that resolves once the client polling process has started.
@@ -31,15 +31,18 @@ export default class EppoClient implements IEppoClient {
     private configurationRequestor: ExperimentConfigurationRequestor,
   ) {}
 
-  getAssignment(subject: string, flag: string): string {
+  getAssignment(subject: string, experimentKey: string): string {
     validateNotBlank(subject, 'Invalid argument: subject cannot be blank');
-    validateNotBlank(flag, 'Invalid argument: flag cannot be blank');
-    const experimentConfig = this.configurationRequestor.getConfiguration(flag);
-    if (!experimentConfig?.enabled || !this.isInExperimentSample(subject, flag, experimentConfig)) {
+    validateNotBlank(experimentKey, 'Invalid argument: experimentKey cannot be blank');
+    const experimentConfig = this.configurationRequestor.getConfiguration(experimentKey);
+    if (
+      !experimentConfig?.enabled ||
+      !this.isInExperimentSample(subject, experimentKey, experimentConfig)
+    ) {
       return null;
     }
     const { variations, subjectShards } = experimentConfig;
-    const shard = getShard(`assignment-${subject}-${flag}`, subjectShards);
+    const shard = getShard(`assignment-${subject}-${experimentKey}`, subjectShards);
     return variations.find((variation) => isShardInRange(shard, variation.shardRange)).name;
   }
 
@@ -50,11 +53,11 @@ export default class EppoClient implements IEppoClient {
    */
   private isInExperimentSample(
     subject: string,
-    experiment: string,
+    experimentKey: string,
     experimentConfig: IExperimentConfiguration,
   ): boolean {
     const { percentExposure, subjectShards } = experimentConfig;
-    const shard = getShard(`exposure-${subject}-${experiment}`, subjectShards);
+    const shard = getShard(`exposure-${subject}-${experimentKey}`, subjectShards);
     return shard <= percentExposure * subjectShards;
   }
 }


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

See discussion in this thread: https://github.com/Eppo-exp/python-sdk/pull/2#discussion_r864275169

## Description

Renamed the `flag` parameter of the assignment function to `experimentKey`. There are no changes besides the rename.
