### PR TITLE
Use LRU cache instead of TTL cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 * Describe deprecated APIs in this version
 -->
 
+## [0.3.7] - 2022-05-05
+
+#### Changed:
+* Changed the in-memory store implementation to use an LRU cache instead of a TTL cache. This allows the assignment function to continue serving stale results if a fatal error stops the polling process.
+
 ## [0.3.6] - 2022-05-03
 
 #### Changed:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.1",
     "http-status-codes": "^2.2.0",
-    "node-cache": "^5.1.2"
+    "lru-cache": "^7.9.0"
   },
   "devDependencies": {
     "@google-cloud/storage": "^5.19.3",
@@ -39,6 +39,7 @@
     "@microsoft/api-extractor": "^7.21.2",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.4.1",
+    "@types/lru-cache": "^7.6.1",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.13.0",
     "eslint": "7.32.0",

--- a/src/configuration-store.spec.ts
+++ b/src/configuration-store.spec.ts
@@ -1,14 +1,19 @@
 import { InMemoryConfigurationStore } from './configuration-store';
 
 describe('InMemoryConfigurationStore', () => {
-  it('clears entries after TTL', () => {
-    jest.useFakeTimers();
-    const store = new InMemoryConfigurationStore<string>(1000);
-    store.setConfigurations({ key1: 'item1', key2: 'item2' });
-    expect(store.getConfiguration('key1')).toEqual('item1');
-    expect(store.getConfiguration('key2')).toEqual('item2');
-    jest.advanceTimersByTime(1011);
-    expect(store.getConfiguration('key1')).toEqual(undefined);
-    expect(store.getConfiguration('key2')).toEqual(undefined);
+  it('evicts entries when max size is exceeded', () => {
+    const maxSize = 1000;
+    const store = new InMemoryConfigurationStore<string>(maxSize);
+    store.setConfigurations({ toBeEvicted: 'item1' });
+    expect(store.getConfiguration('toBeEvicted')).toEqual('item1');
+    const otherConfigs = {};
+    for (let i = 0; i < maxSize; i++) {
+      otherConfigs[`key-${i}`] = `value-${i}`;
+    }
+    store.setConfigurations(otherConfigs);
+    expect(store.getConfiguration('toBeEvicted')).toEqual(undefined);
+    for (let i = 0; i < maxSize; i++) {
+      expect(store.getConfiguration(`key-${i}`)).toEqual(`value-${i}`);
+    }
   });
 });

--- a/src/configuration-store.ts
+++ b/src/configuration-store.ts
@@ -1,4 +1,4 @@
-import * as NodeCache from 'node-cache';
+import * as LRUCache from 'lru-cache';
 
 export interface IConfigurationStore<T> {
   getConfiguration(key: string): T;
@@ -9,9 +9,9 @@ export interface IConfigurationStore<T> {
  * Default ConfigurationStore implementation. Sets and retrieves entries from an in-memory cache.
  */
 export class InMemoryConfigurationStore<T> implements IConfigurationStore<T> {
-  private cache: NodeCache;
-  constructor(ttlMilliseconds: number) {
-    this.cache = new NodeCache({ stdTTL: ttlMilliseconds / 1000 }); // divide by 1000 because NodeCache uses seconds
+  private cache: LRUCache<string, T>;
+  constructor(maxEntries: number) {
+    this.cache = new LRUCache({ max: maxEntries });
   }
 
   getConfiguration(key: string): T {
@@ -19,10 +19,8 @@ export class InMemoryConfigurationStore<T> implements IConfigurationStore<T> {
   }
 
   setConfigurations(configs: Record<string, T>) {
-    const cacheEntries: NodeCache.ValueSetItem<T>[] = Object.entries(configs).map(([key, val]) => ({
-      key,
-      val,
-    }));
-    this.cache.mset(cacheEntries);
+    Object.entries(configs).forEach(([key, val]) => {
+      this.cache.set(key, val);
+    });
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ const MINUTE_MILLIS = 60 * SECOND_MILLIS;
 
 export const POLL_INTERVAL_MILLIS = 5 * MINUTE_MILLIS;
 export const JITTER_MILLIS = 30 * SECOND_MILLIS;
-export const CACHE_TTL_MILLIS = 15 * MINUTE_MILLIS;
+export const MAX_CACHE_ENTRIES = 1000;
 export const REQUEST_TIMEOUT_MILLIS = SECOND_MILLIS;
 
 export const BASE_URL = 'https://eppo.cloud/api';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { InMemoryConfigurationStore } from './configuration-store';
 import {
   BASE_URL,
-  CACHE_TTL_MILLIS,
+  MAX_CACHE_ENTRIES,
   JITTER_MILLIS,
   POLL_INTERVAL_MILLIS,
   REQUEST_TIMEOUT_MILLIS,
@@ -47,7 +47,7 @@ let poller: IPoller = null;
 export function init(config: IClientConfig): IEppoClient {
   validateNotBlank(config.apiKey, 'API key required');
   const configurationStore = new InMemoryConfigurationStore<IExperimentConfiguration>(
-    CACHE_TTL_MILLIS,
+    MAX_CACHE_ENTRIES,
   );
   const axiosInstance = axios.create({
     baseURL: config.baseUrl || BASE_URL,

--- a/yarn.lock
+++ b/yarn.lock
@@ -846,6 +846,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lru-cache@^7.6.1":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-7.6.1.tgz#99809260ef1e870b8ef2ab3a625784a33cec5ba9"
+  integrity sha512-69x+Dhrm2aShFkTqUuPgUXbKYwvq4FH/DVeeQH7MBfTjbKjPX51NGLERxVV1vf33N71dzLvXCko4OLqRvsq53Q==
+
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
@@ -1434,11 +1439,6 @@ cliui@^7.0.2:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
-
-clone@2.x:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
 co@^4.6.0:
   version "4.6.0"
@@ -3464,6 +3464,11 @@ lru-cache@^7.4.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.8.0.tgz#649aaeb294a56297b5cbc5d70f198dcc5ebe5747"
   integrity sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==
 
+lru-cache@^7.9.0:
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.9.0.tgz#29c2a989b6c10f32ceccc66ff44059e1490af3e1"
+  integrity sha512-lkcNMUKqdJk96TuIXUidxaPuEg5sJo/+ZyVE2BDFnuZGzwXem7d8582eG8vbu4todLfT14snP6iHriCHXXi5Rw==
+
 make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -3579,13 +3584,6 @@ negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
-
-node-cache@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
-  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
-  dependencies:
-    clone "2.x"
 
 node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

See discussion in this thread: https://github.com/Eppo-exp/python-sdk/pull/3#discussion_r866301635

The advantage of using an LRU cache instead of a TTL cache is that it allows the SDK to continue serving stale results for some time after a fatal error in the polling process. Although, the cache will still get cleared if there is a deployment.

## Description
[//]: # (Describe your changes in detail)

Swapped the node-cache library for the LRUCache library. I set a max size of 1000. This is a mostly arbitrary limit. Assuming each experiment config is around 100bytes, the cache may grow to roughly 100kb.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Added a unit test to make sure old entries are evicted when the max size is exceeded.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
