### PR TITLE
Node SDK - implement allow list

### DIFF
--- a/src/experiment/experiment-configuration.ts
+++ b/src/experiment/experiment-configuration.ts
@@ -6,4 +6,5 @@ export interface IExperimentConfiguration {
   enabled: boolean;
   subjectShards: number;
   variations: IVariation[];
+  overrides: Record<string, string>;
 }

--- a/test/mockApiServer.ts
+++ b/test/mockApiServer.ts
@@ -16,6 +16,7 @@ api.get('/randomized_assignment/config', (_req, res) => {
       enabled: true,
       subjectShards: 10000,
       variations,
+      overrides: {},
     };
   });
   res.json({


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Customers want to define an allowlist or override such that the same variation is always returned for subjects in the allowlist.

## Description
[//]: # (Describe your changes in detail)

Use the `overrides` field from the RAC response to return variation override.
