### PR TITLE
Allow assigning subject from overrides when experiment is not enabled

### DIFF
--- a/docs/node-server-sdk.iclientconfig.assignmentlogger.md
+++ b/docs/node-server-sdk.iclientconfig.assignmentlogger.md
@@ -9,5 +9,5 @@ Pass a logging implementation to send variation assignments to your data warehou
 <b>Signature:</b>
 
 ```typescript
-assignmentLogger?: IAssignmentLogger;
+assignmentLogger: IAssignmentLogger;
 ```

--- a/docs/node-server-sdk.iclientconfig.md
+++ b/docs/node-server-sdk.iclientconfig.md
@@ -17,6 +17,6 @@ export interface IClientConfig
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [apiKey](./node-server-sdk.iclientconfig.apikey.md) | string | Eppo API key |
-|  [assignmentLogger?](./node-server-sdk.iclientconfig.assignmentlogger.md) | [IAssignmentLogger](./node-server-sdk.iassignmentlogger.md) | <i>(Optional)</i> Pass a logging implementation to send variation assignments to your data warehouse. |
+|  [assignmentLogger](./node-server-sdk.iclientconfig.assignmentlogger.md) | [IAssignmentLogger](./node-server-sdk.iassignmentlogger.md) | Pass a logging implementation to send variation assignments to your data warehouse. |
 |  [baseUrl?](./node-server-sdk.iclientconfig.baseurl.md) | string | <i>(Optional)</i> Base URL of the Eppo API. Clients should use the default setting in most cases. |
 

--- a/node-server-sdk.api.md
+++ b/node-server-sdk.api.md
@@ -25,7 +25,7 @@ export interface IAssignmentLogger {
 // @public
 export interface IClientConfig {
     apiKey: string;
-    assignmentLogger?: IAssignmentLogger;
+    assignmentLogger: IAssignmentLogger;
     baseUrl?: string;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [

--- a/src/eppo-client.spec.ts
+++ b/src/eppo-client.spec.ts
@@ -18,14 +18,14 @@ describe('EppoClient E2E test', () => {
       name: 'control',
       shardRange: {
         start: 0,
-        end: 33,
+        end: 34,
       },
     },
     {
       name: 'variant-1',
       shardRange: {
         start: 34,
-        end: 66,
+        end: 67,
       },
     },
     {
@@ -83,13 +83,31 @@ describe('EppoClient E2E test', () => {
     );
   });
 
-  it('returns subject from overrides', () => {
+  it('assigns subject from overrides when experiment is enabled', () => {
     const mockConfigRequestor = td.object<ExperimentConfigurationRequestor>();
     const experiment = 'experiment_5';
     td.when(mockConfigRequestor.getConfiguration(experiment)).thenReturn({
       name: experiment,
       percentExposure: 1,
       enabled: true,
+      subjectShards: 100,
+      variations: mockVariations,
+      overrides: {
+        a90ea45116d251a43da56e03d3dd7275: 'variant-2',
+      },
+    });
+    const client = new EppoClient(mockConfigRequestor);
+    const assignment = client.getAssignment('subject-1', experiment);
+    expect(assignment).toEqual('variant-2');
+  });
+
+  it('assigns subject from overrides when experiment is not enabled', () => {
+    const mockConfigRequestor = td.object<ExperimentConfigurationRequestor>();
+    const experiment = 'experiment_5';
+    td.when(mockConfigRequestor.getConfiguration(experiment)).thenReturn({
+      name: experiment,
+      percentExposure: 0,
+      enabled: false,
       subjectShards: 100,
       variations: mockVariations,
       overrides: {

--- a/src/eppo-client.spec.ts
+++ b/src/eppo-client.spec.ts
@@ -119,6 +119,15 @@ describe('EppoClient E2E test', () => {
     expect(assignment).toEqual('variant-2');
   });
 
+  it('returns null when experiment config is absent', () => {
+    const mockConfigRequestor = td.object<ExperimentConfigurationRequestor>();
+    const experiment = 'experiment_5';
+    td.when(mockConfigRequestor.getConfiguration(experiment)).thenReturn(null);
+    const client = new EppoClient(mockConfigRequestor);
+    const assignment = client.getAssignment('subject-1', experiment);
+    expect(assignment).toEqual(null);
+  });
+
   it('logs variation assignment', () => {
     const mockConfigRequestor = td.object<ExperimentConfigurationRequestor>();
     const mockLogger = td.object<IAssignmentLogger>();

--- a/src/eppo-client.spec.ts
+++ b/src/eppo-client.spec.ts
@@ -10,9 +10,14 @@ import ExperimentConfigurationRequestor from './experiment/experiment-configurat
 import { IVariation } from './experiment/variation';
 import { OperatorType } from './rule';
 
-import { getInstance, IAssignmentLogger, init } from '.';
+import { getInstance, IAssignmentEvent, IAssignmentLogger, init } from '.';
 
 describe('EppoClient E2E test', () => {
+  const mockLogger: IAssignmentLogger = {
+    logAssignment(assignment: IAssignmentEvent) {
+      console.log(`Logged assignment for subject ${assignment.subject}`);
+    },
+  };
   const mockVariations = [
     {
       name: 'control',
@@ -40,7 +45,7 @@ describe('EppoClient E2E test', () => {
   jest.useFakeTimers();
 
   beforeAll(async () => {
-    await init({ apiKey: 'dummy', baseUrl: 'http://127.0.0.1:4000' });
+    await init({ apiKey: 'dummy', baseUrl: 'http://127.0.0.1:4000', assignmentLogger: mockLogger });
   });
 
   afterAll(async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export interface IClientConfig {
   /**
    * Pass a logging implementation to send variation assignments to your data warehouse.
    */
-  assignmentLogger?: IAssignmentLogger;
+  assignmentLogger: IAssignmentLogger;
 }
 
 export { IAssignmentEvent, IAssignmentLogger } from './assignment-logger';


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes Eppo-exp/eppo#3871
Fixes Eppo-exp/eppo#3879

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Currently, the experiment has to be enabled for the allow list to work. But the allow list should work regardless of the experiment status or traffic allocation, since it is used for QA.

## Description
[//]: # (Describe your changes in detail)

Do the allow list override check as the first part of the assignment function.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Added unit test


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
