### PR TITLE
Pavel/epd 1022 oom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -5,6 +5,7 @@ import { IAllocation } from '../dto/allocation-dto';
 import { IExperimentConfiguration } from '../dto/experiment-configuration-dto';
 import { IRule } from '../dto/rule-dto';
 import ExperimentConfigurationRequestor from '../experiment-configuration-requestor';
+import { IPoller } from '../poller';
 import { findMatchingRule } from '../rule_evaluator';
 import { getShard, isShardInRange } from '../shard';
 import { validateNotBlank } from '../validation';
@@ -35,6 +36,7 @@ export interface IEppoClient {
 export default class EppoClient implements IEppoClient {
   constructor(
     private configurationRequestor: ExperimentConfigurationRequestor,
+    private poller: IPoller,
     private assignmentLogger?: IAssignmentLogger,
   ) {}
 
@@ -81,6 +83,10 @@ export default class EppoClient implements IEppoClient {
       console.error(`[Eppo SDK] Error logging assignment event: ${error.message}`);
     }
     return assignedVariation;
+  }
+
+  public stopClient() {
+    this.poller.stop();
   }
 
   private getSubjectVariationOverride(

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -85,7 +85,7 @@ export default class EppoClient implements IEppoClient {
     return assignedVariation;
   }
 
-  public stopClient() {
+  public stopPolling() {
     this.poller.stop();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
     JITTER_MILLIS,
     configurationRequestor.fetchAndStoreConfigurations.bind(configurationRequestor),
   );
-  clientInstance = new EppoClient(configurationRequestor, config.assignmentLogger);
+  clientInstance = new EppoClient(configurationRequestor, poller, config.assignmentLogger);
   await poller.start();
   return clientInstance;
 }


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: EPD-1022

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

There is quite a complex issue with OOM, best seen in e2e tests of the main repo.
For this to be fixed, we need to be able to stop polling manually via the EppoSDKClient.

## Description
[//]: # (Describe your changes in detail)

After adding eppo sdk client to api e2e tests in main repo (in this [PR](https://github.com/Eppo-exp/eppo/pull/5506/files))
we started to hit OOM error (while running jest, locally or in GH Actions).
After some research I found out that eppo sdk is causing this issue.
My logic here is:
- init of EppoSDK starts polling which is done via recursive `setTimeout` calls.
- The recursion continues until poller.stop method is called;
- poller.stop method never called;
Also, I saw the issue in this GH action: https://github.com/Eppo-exp/eppo/actions/runs/4043339513/jobs/6952139426

```
  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Error polling configurations: connect ECONNREFUSED ::1:4000".

      at console.error (node_modules/@jest/console/build/BufferedConsole.js:127:10)
      at Timeout.poll [as _onTimeout] (node_modules/@eppo/node-server-sdk/src/poller.ts:27:15)


  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Error polling configurations: connect ECONNREFUSED ::1:4000".

      at console.error (node_modules/@jest/console/build/BufferedConsole.js:127:10)
      at Timeout.poll [as _onTimeout] (node_modules/@eppo/node-server-sdk/src/poller.ts:27:15)


  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Error polling configurations: connect ECONNREFUSED ::1:4000".

      at console.error (node_modules/@jest/console/build/BufferedConsole.js:127:10)
      at Timeout.poll [as _onTimeout] (node_modules/@eppo/node-server-sdk/src/poller.ts:27:15)
```

even if this does not lead to OOM issue itself, it prevents Jest from exiting. (Jest has an issue with OOM, which I fixed in the PR (ADD LINK TO PR HERE)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
