### PR TITLE
Split getJSONAssignment into getJSONStringAssignment and getParsedJSONAssignment by bumping common library version (FF-898)

### DIFF
--- a/node-server-sdk.api.md
+++ b/node-server-sdk.api.md
@@ -12,7 +12,6 @@ import { IAssignmentEvent } from '@eppo/js-client-sdk-common';
 import { IAssignmentLogger } from '@eppo/js-client-sdk-common';
 import { IConfigurationStore } from '@eppo/js-client-sdk-common';
 import { IEppoClient as IEppoClient_2 } from '@eppo/js-client-sdk-common';
-import { IExperimentConfiguration } from '@eppo/js-client-sdk-common/dist/dto/experiment-configuration-dto';
 
 // @public
 export function getInstance(): IEppoClient;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "axios": "^0.27.2",
     "http-status-codes": "^2.2.0",
     "lru-cache": "^9.1.1",
-    "@eppo/js-client-sdk-common": "^1.4.1"
+    "@eppo/js-client-sdk-common": "^1.5.0"
   },
   "devDependencies": {
     "@google-cloud/storage": "^6.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "axios": "^0.27.2",
     "http-status-codes": "^2.2.0",
     "lru-cache": "^9.1.1",
-    "@eppo/js-client-sdk-common": "^1.5.0"
+    "@eppo/js-client-sdk-common": "^1.5.1"
   },
   "devDependencies": {
     "@google-cloud/storage": "^6.9.3",

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -7,9 +7,16 @@ export const TEST_DATA_DIR = './test/data/';
 export const ASSIGNMENT_TEST_DATA_DIR = TEST_DATA_DIR + 'assignment-v2/';
 export const MOCK_RAC_RESPONSE_FILE = 'rac-experiments-v3.json';
 
+export enum ValueTestType {
+  BoolType = 'boolean',
+  NumericType = 'numeric',
+  StringType = 'string',
+  JSONType = 'json',
+}
+
 export interface IAssignmentTestCase {
   experiment: string;
-  valueType: string;
+  valueType: ValueTestType;
   percentExposure: number;
   variations: IVariation[];
   subjects: string[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,7 +292,7 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eppo/js-client-sdk-common@^1.4.1":
+"@eppo/js-client-sdk-common@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.5.0.tgz#b18ee3f4506605813865b251411d1ee02a6e4825"
   integrity sha512-mxM9tJInCUWMkS3hjlMil2pPMYMrryaaM+zw7Uxatq/ILKYD64RqyFa/6iO3L9M0tv6Tcl3weWvQKE5Nurj0YA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,10 +292,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eppo/js-client-sdk-common@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.5.0.tgz#b18ee3f4506605813865b251411d1ee02a6e4825"
-  integrity sha512-mxM9tJInCUWMkS3hjlMil2pPMYMrryaaM+zw7Uxatq/ILKYD64RqyFa/6iO3L9M0tv6Tcl3weWvQKE5Nurj0YA==
+"@eppo/js-client-sdk-common@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.5.1.tgz#f4f86c17aaf8da565613a85ffc6b5f133a382a6a"
+  integrity sha512-cO7lkqO1I0d3aOu43+jeiUTNFn4Rkrg95Fc6ADhLFwYjV3b0hI7KRUPE66YadjgP3Db3J2XgBWtQps2XFbfe5Q==
   dependencies:
     axios "^0.27.2"
     md5 "^2.3.0"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: [FF-898](https://linear.app/eppo/issue/FF-898/node-server)

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

* Bumps common library version to [v1.5.1](https://github.com/Eppo-exp/js-client-sdk-common/releases/tag/v1.5.1)
  * [v1.5.0](https://github.com/Eppo-exp/js-client-sdk-common/releases/tag/v1.5.0) splits `getJSONAssignment` into `getJSONStringAssignment` and `getParsedJSONAssignment`
  * [v1.5.1](https://github.com/Eppo-exp/js-client-sdk-common/releases/tag/v1.5.1) has a bug fix that includes `getParsedJSONAssignment` as a property in `IEppoClient`
* Adds tests to support each of the typed assignment methods

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Running `yarn test`

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
