### PR TITLE
update node version in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: npm install
       - run: npm test
       - uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
Bumping in order to fix the publish action:

```
error @eppo/node-server-sdk@3.0.0: The engine "node" is incompatible with this module. Expected version ">=18.x". Got "16.20.2"
```
