### PR TITLE
[UFC] Clear config store before loading new config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [

--- a/src/configuration-store.spec.ts
+++ b/src/configuration-store.spec.ts
@@ -16,4 +16,17 @@ describe('InMemoryConfigurationStore', () => {
       expect(store.get(`key-${i}`)).toEqual(`value-${i}`);
     }
   });
+
+  it('evicts entries when new entries are loaded', () => {
+    const maxSize = 1000;
+    const store = new InMemoryConfigurationStore(maxSize);
+
+    store.setEntries({ "hello": "world", "bye": "world"});
+    expect(store.get("hello")).toEqual("world");
+    expect(store.get("bye")).toEqual("world");
+
+    store.setEntries({ "hello": "world"});
+    expect(store.get("hello")).toEqual("world");
+    expect(store.get("bye")).toEqual(null);
+  })
 });

--- a/src/configuration-store.ts
+++ b/src/configuration-store.ts
@@ -26,6 +26,7 @@ export class InMemoryConfigurationStore implements IConfigurationStore {
   }
 
   setEntries<T>(entries: Record<string, T>) {
+    this.cache.clear();
     Object.entries(entries).forEach(([key, val]) => {
       this.cache.set(key, val);
     });


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #ff-1990

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

We need to ensure flags that are no longer in the config are removed when updating the configuration

## Description
[//]: # (Describe your changes in detail)

Clear the configuration store before loading new flags

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Added a unit test


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
