### PR TITLE
v3.0.3-rc.0

### DIFF
--- a/.github/workflows/nodejs-setup.yml
+++ b/.github/workflows/nodejs-setup.yml
@@ -1,0 +1,30 @@
+name: Node.js Setup and Test
+on:
+  workflow_call:
+    inputs:
+      node_version:
+        required: true
+        type: string
+      npm_tag:
+        required: false
+        type: string
+      npm_token:
+        required: true
+        type: string
+
+jobs:
+  setup-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node_version }}
+      - run: npm install
+      - run: npm test
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ inputs.npm_token }}
+          access: public
+          tag: ${{ inputs.npm_tag }}
+          

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -1,11 +1,11 @@
-name: Publish to NPM
+name: Publish RC to NPM
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:
     uses: ./.github/workflows/nodejs-setup.yml
     with:
       node_version: '18.x'
+      npm_tag: rc
       npm_token: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "3.0.2",
+  "version": "3.0.3-rc.0",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Experimenting with a release process that allows us to have "release candidates" that we can explicitly add to our services and dogfood before publishing for our customers. 

## Description
[//]: # (Describe your changes in detail)

**Bumping the version programmatically:**

```
➜  node-server-sdk git:(main) yarn version --new-version prerelease --preid rc
yarn version v1.22.22
info Current version: 3.0.2
info New version: 3.0.3-rc.0
✨  Done in 7.75s.
```

**To publish this version:**

Caveat: this is different than our normal publish command. There is a new github action in this PR that can be executed manually.

```
yarn publish --tag rc
```

**For end-users to install:**

```
yarn add @eppo/node-server-sdk@3.0.3-rc.0
```

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
