### PR TITLE
Expose bandit logger types

### DIFF
--- a/node-server-sdk.api.md
+++ b/node-server-sdk.api.md
@@ -6,6 +6,7 @@
 
 import { IAssignmentEvent } from '@eppo/js-client-sdk-common';
 import { IAssignmentLogger } from '@eppo/js-client-sdk-common';
+import { IBanditEvent } from '@eppo/js-client-sdk-common';
 import { IBanditLogger } from '@eppo/js-client-sdk-common';
 import { IEppoClient } from '@eppo/js-client-sdk-common';
 
@@ -15,6 +16,10 @@ export function getInstance(): IEppoClient;
 export { IAssignmentEvent }
 
 export { IAssignmentLogger }
+
+export { IBanditEvent }
+
+export { IBanditLogger }
 
 // @public
 export interface IClientConfig {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Eppo-exp/node-server-sdk#readme",
   "dependencies": {
-    "@eppo/js-client-sdk-common": "3.5.0",
+    "@eppo/js-client-sdk-common": "3.6.0",
     "lru-cache": "^10.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,12 @@ export interface IClientConfig {
   pollAfterFailedInitialization?: boolean;
 }
 
-export { IAssignmentEvent, IAssignmentLogger } from '@eppo/js-client-sdk-common';
+export {
+  IAssignmentEvent,
+  IAssignmentLogger,
+  IBanditEvent,
+  IBanditLogger,
+} from '@eppo/js-client-sdk-common';
 
 let clientInstance: IEppoClient;
 

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -97,7 +97,8 @@ export function validateTestAssignments(
       // the expect works well for objects, but this comparison does not
       if (assignment !== subject.assignment) {
         throw new Error(
-          `subject ${subject.subjectKey
+          `subject ${
+            subject.subjectKey
           } was assigned ${assignment?.toString()} when expected ${subject.assignment?.toString()} for flag ${flag}`,
         );
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,10 +460,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eppo/js-client-sdk-common@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-3.5.0.tgz#456616067a7044707828eea596cf6915d9c21c71"
-  integrity sha512-uCzPXRq7Z7Ir8a9XDz0YU3TP5F1vKYtKqXSjRjqViDSBBfbdTkHBNh1zeA3hEdpppjQKZHExbV1Stl0rmNWznw==
+"@eppo/js-client-sdk-common@3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-3.6.0.tgz#b67cff89809f10df8a1b5619c4e6bec701f6d2c8"
+  integrity sha512-9G43xdGUwLJPiwvO6OUTqwFuko6nvD6FgrsCUroRVPQbHrOnWbyylAE8h2vwbxIhSTlLwxS0xRqWO+WEYiWepA==
   dependencies:
     js-base64 "^3.7.7"
     md5 "^2.3.0"


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** FF-2584 - Export common bandit logger types

Users may want to use the bandit logger types when defining loggers, just as they do with assignment logging
