### PR TITLE
Bump common SDK version for updated handling of no-action bandits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Eppo-exp/node-server-sdk#readme",
   "dependencies": {
-    "@eppo/js-client-sdk-common": "4.0.0",
+    "@eppo/js-client-sdk-common": "4.0.1",
     "lru-cache": "^10.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,10 +460,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eppo/js-client-sdk-common@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.0.0.tgz#39dea02745b641915fa4e925d75a12ca5b1e9503"
-  integrity sha512-aMru8KESyNJDU/fm5jVENUhpa1jB88FUncT/xnjgiWPuTLLrpi10Qshoj7Lloi8IjlwFSFMjDjtpuQoLKPpQXA==
+"@eppo/js-client-sdk-common@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.0.1.tgz#ed937fd1314889601a7074ff0d5c09928cb1e26a"
+  integrity sha512-YZ+ILbiPZs4JHPc6Npm0DUT8Pnb2t3mxZEy9y2wYSWMvRvy+BNIW4R5HGBC44aXchmo+FkpJiTzC+uoD2SB9Gg==
   dependencies:
     js-base64 "^3.7.7"
     md5 "^2.3.0"


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-2816 - Update Node SDK to use updated Common SDK for no-action bandit calls](https://linear.app/eppo/issue/FF-2816/update-node-sdk-to-use-updated-common-sdk-for-no-action-bandit-calls)

## Motivation and Context
We changed how we handle the situation where no actions are passed to `getBanditAction()`, now always returning the bandit variation if assigned even if no actions are passed (or there was an error selecting an action).

## Description
To achieve this, we pull in the latest version of the common SDK where this is supported. See [`js-client-sdk-common #115`](https://github.com/Eppo-exp/js-client-sdk-common/pull/115).

## How has this been tested?
Passes the updated shared bandit test cases (see [`sdk-test-data #46`](https://github.com/Eppo-exp/sdk-test-data/pull/46))
<img width="711" alt="image" src="https://github.com/user-attachments/assets/f692fcd1-221c-4133-925e-3a441f3a8885">


