### PR TITLE
Quality: Parameterize SDK and test-data branches

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -1,4 +1,9 @@
 name: Lint and Test SDK
+
+env:
+  SDK_BRANCH_NAME: ${{ inputs.sdk_branch  || github.head_ref || github.ref_name || 'main' }}
+  TEST_DATA_BRANCH_NAME: ${{ inputs.test_data_branch || 'main' }}
+
 on:
   pull_request:
     branches: [ "*" ]
@@ -14,7 +19,7 @@ on:
         type: string
         description: The branch of the SDK to test
         required: false
-
+          
 jobs:
   lint-test-sdk:
     runs-on: ubuntu-latest
@@ -22,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: Eppo-exp/node-server-sdk
-          ref: ${{ github.event.inputs.sdk_branch || github.head_ref || github.ref_name || 'main' }}
+          ref: ${{ env.SDK_BRANCH_NAME }}
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
@@ -43,7 +48,7 @@ jobs:
         run: npx eslint '**/*.{ts,tsx}'
         working-directory: ./
       - name: Run unit and e2e tests
-        run: make test branchName=${{ github.event.inputs.test_data_branch || 'main' }}
+        run: make test branchName=${{ env.TEST_DATA_BRANCH_NAME }}
         working-directory: ./
   typecheck:
     runs-on: ubuntu-latest
@@ -51,7 +56,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: Eppo-exp/node-server-sdk
-          ref: ${{ github.event.inputs.sdk_branch || github.head_ref || github.ref_name || 'main' }}
+          ref: ${{ env.SDK_BRANCH_NAME }}
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -1,13 +1,24 @@
 name: Lint and Test SDK
 on:
   pull_request:
-    path: '**/*'
+    branches: [ "*" ]
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      test_data_branch:
+        type: string
+        description: The branch in sdk-test-data to target for testcase files
+        required: false
+        default: main
 
 jobs:
   lint-test-sdk:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          repository: Eppo-exp/node-server-sdk
+          ref: ${{ github.head_ref || github.ref_name || 'main' }}
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
@@ -27,13 +38,16 @@ jobs:
       - name: Check code with eslint
         run: npx eslint '**/*.{ts,tsx}'
         working-directory: ./
-      - name: Run unit tests
-        run: yarn test:unit
+      - name: Run unit and e2e tests
+        run: make test branchName=${{ github.event.inputs.test_data_branch || 'main' }}
         working-directory: ./
   typecheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          repository: Eppo-exp/node-server-sdk
+          ref: ${{ github.head_ref || github.ref_name || 'main' }}
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -10,6 +10,10 @@ on:
         description: The branch in sdk-test-data to target for testcase files
         required: false
         default: main
+      sdk_branch:
+        type: string
+        description: The branch of the SDK to test
+        required: false
 
 jobs:
   lint-test-sdk:
@@ -18,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: Eppo-exp/node-server-sdk
-          ref: ${{ github.head_ref || github.ref_name || 'main' }}
+          ref: ${{ github.event.inputs.sdk_branch || github.head_ref || github.ref_name || 'main' }}
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
@@ -47,7 +51,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: Eppo-exp/node-server-sdk
-          ref: ${{ github.head_ref || github.ref_name || 'main' }}
+          ref: ${{ github.event.inputs.sdk_branch || github.head_ref || github.ref_name || 'main' }}
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -39,8 +39,6 @@ jobs:
       - name: Install root dependencies
         run: yarn --frozen-lockfile
         working-directory: ./
-      - name: 'Set up GCP SDK for downloading test data'
-        uses: 'google-github-actions/setup-gcloud@v0'
       - name: Install sdk dependencies
         run: yarn --frozen-lockfile
         working-directory: ./

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test-data:
 
 ## test
 .PHONY: test
-test: test
+test: test test-data
 	yarn test:unit
 
 ## prepare


### PR DESCRIPTION
🎟️ Fixes FF-3089 towards FF-3085

👯‍♂️ **Related PRs**
- [sdk-test-data#57](https://github.com/Eppo-exp/sdk-test-data/pull/57)
- [php-sdk#38](https://github.com/Eppo-exp/php-sdk/pull/38)
- [dot-net-server-sdk#44](https://github.com/Eppo-exp/dot-net-server-sdk/pull/44)


### Motivation
Changes are often made to the [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data) repository to capture new behaviours, bugs and edge cases. When these changes are pushed to `main`, the SDKs are cloned locally (locally to the github action running) and their respective tests are run. These tests are set up and run by copies of the SDK test workflows - see [sdk-test-data workflow](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows/test-sdks.yml). There are a number of limitations to this setup:

- Test steps are copied from the SDK’s respective workflows; changes to the SDK test workflows need to be replicated in sdk-test-data and this is not obvious to devs
- The SDK tests are not able to run against in-flight changes to `sdk-test-data`
- When new test-data is committed that breaks an SDK, that breakage is not surfaced in the SDK’s repository until some action triggers its testing workflow (on demand, on pull-request, etc.).

### Description of Changes
_This change_
🚀 - Each SDK's testing workflow is enhanced into a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows), exposing parameters for SDK branch and the sdk-test-data branch to use in testing.
- The test workflow runs using the main branch of sdk-test-data on all main pushes and Pull Requests using the PR's branch

_External to this Change_
[sdk-test-data](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows) get two testing workflows.
1. ♻️  "Local Testing"- For all pull request changes, the "Local Testing" workflow calls the reusable SDK workflows, test results are recorded only in the sdk-test-data action. This is run using the main SDK branch and the "current" branch of workflow, i.e. the pull request branch. (SDK repo does not see/is not notified of test failures during PR lifecycle, only on push to main)
2. ♻️ 🧑‍💻 "Remote Testing" - On all pushes to the main branch of sdk-test-data, the SDK testing workflows are triggered to run within their respective repositories, alerting all subscribers of failed runs (repo is red/green).