### PR TITLE
Bump version of common js client to take advantage of bandit assignment caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Eppo-exp/node-server-sdk#readme",
   "dependencies": {
-    "@eppo/js-client-sdk-common": "4.0.2",
+    "@eppo/js-client-sdk-common": "4.1.0",
     "lru-cache": "^10.0.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,7 @@ export async function init(config: IClientConfig): Promise<EppoClient> {
   // we estimate this will use no more than 10 MB of memory
   // and should be appropriate for most server-side use cases.
   clientInstance.useLRUInMemoryAssignmentCache(50_000);
+  clientInstance.useLRUInMemoryBanditAssignmentCache(50_000);
 
   // Fetch configurations (which will also start regular polling per requestConfiguration)
   await clientInstance.fetchFlagConfigurations();

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,10 +460,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eppo/js-client-sdk-common@4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.0.2.tgz#fb99445ad57d6593d0f9bbc70a2e1327ea962b41"
-  integrity sha512-S9RUxsrHJEl5ePMx9929aiw1uPlv3AxH82iJIJgsuSpLbi3w1EkEo17J/2B4505EI20G9XYLY3fWM0eOUR4WKw==
+"@eppo/js-client-sdk-common@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.1.0.tgz#fc1b625ef2997a82cb65c6e8a43fb7894196b205"
+  integrity sha512-bUA/k9HfhdGkSp7mnmKRg5VJAY+JORGoCV3eSU+Dn39gr0IQARw3VHJ3QIaKSciwoEe51n2Mk8K7/XdiIV6Qiw==
   dependencies:
     js-base64 "^3.7.7"
     md5 "^2.3.0"


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-3144 - Node SDK - Assignment cache should work at the bandit action level](https://linear.app/eppo/issue/FF-3144/node-sdk-assignment-cache-should-work-at-the-bandit-action-level)
👯 **Related PR:** [`js-client-sdk-common #120`](https://github.com/Eppo-exp/js-client-sdk-common/pull/120)

## Motivation and Context
Do not invoke logging callback if the same bandit and action were assigned immediately before

## Description
Bump the version of the common SDK so that we can take advantage of this new functionality

## How has this been tested?
Tests in the common SDK