### PR TITLE
Selki/ff3396 expiring bandit cache

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ let clientInstance: EppoClient;
 export async function init(config: IClientConfig): Promise<EppoClient> {
   validation.validateNotBlank(config.apiKey, 'API key required');
 
-  const requestConfiguration: FlagConfigurationRequestParameters = {
+  const configurationRequestParameters: FlagConfigurationRequestParameters = {
     apiKey: config.apiKey,
     sdkName,
     sdkVersion,
@@ -110,12 +110,12 @@ export async function init(config: IClientConfig): Promise<EppoClient> {
   const banditVariationConfigurationStore = new MemoryOnlyConfigurationStore<BanditVariation[]>();
   const banditModelConfigurationStore = new MemoryOnlyConfigurationStore<BanditParameters>();
 
-  clientInstance = new EppoClient(
+  clientInstance = new EppoClient({
     flagConfigurationStore,
     banditVariationConfigurationStore,
     banditModelConfigurationStore,
-    requestConfiguration,
-  );
+    configurationRequestParameters,
+  });
   clientInstance.setAssignmentLogger(config.assignmentLogger);
   if (config.banditLogger) {
     clientInstance.setBanditLogger(config.banditLogger);

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,9 @@ export async function init(config: IClientConfig): Promise<EppoClient> {
   // we estimate this will use no more than 10 MB of memory
   // and should be appropriate for most server-side use cases.
   clientInstance.useLRUInMemoryAssignmentCache(50_000);
-  clientInstance.useLRUInMemoryBanditAssignmentCache(50_000);
+  // for bandits variant of LRU cache is use, that will
+  // expire on its own after set time. Defaults to 10 minutes
+  clientInstance.useExpiringInMemoryBanditAssignmentCache(50_000);
 
   // Fetch configurations (which will also start regular polling per requestConfiguration)
   await clientInstance.fetchFlagConfigurations();


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #[issue](https://linear.app/eppo/issue/FF-3396/js-sdk-bandit-cache-needs-to-expire-after-a-short-time)

## Motivation and Context
[//](https://github.com/Eppo-exp/node-server-sdk/pull/79#): # We want to use an expiring cache for bandits to dedupe ones from the same session e.g., if a user rapidly refreshes or the assignment is used on multiple parts of a page. We think a 10-minute expiration will be a good starting point for this.

## Description
[//]: # Used TLRU cache on init of EppoClient

## How has this been tested?
[//]: # Unit tests

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
