### PR TITLE
fix: Specify repo and ref in workflow as it is reusable

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -28,6 +28,10 @@ jobs:
         node-version: [ '18', '20', '22', '23' ]
     steps:
       - uses: actions/checkout@v3
+        with:
+          repository: Eppo-exp/node-server-sdk
+          ref: ${{ env.SDK_BRANCH_NAME }}
+
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
@@ -61,6 +65,10 @@ jobs:
         node-version: [ '18', '20', '22', '23' ]
     steps:
       - uses: actions/checkout@v3
+        with:
+          repository: Eppo-exp/node-server-sdk
+          ref: ${{ env.SDK_BRANCH_NAME }}
+
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Fixes: FF-3646

## Motivation and Context
Testing for in-flight data changes requires running the `lint-and-test.yml` as a reusable workflow within the `sdk-test-data` repository. The checkout action assumes the host repo and target branch for the `repository` and `ref` params, so we need to explicitly set them.

![image](https://github.com/user-attachments/assets/b376a483-c230-44a2-8202-a02fb99e25b0)

## Description
- restore dropped parameters

## How has this been tested?
Reusable testing workflow works.
