### PR TITLE
Remove unused lru-cache dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   },
   "homepage": "https://github.com/Eppo-exp/node-server-sdk#readme",
   "dependencies": {
-    "@eppo/js-client-sdk-common": "^4.5.1",
-    "lru-cache": "^10.0.1"
+    "@eppo/js-client-sdk-common": "^4.5.1"
   },
   "devDependencies": {
     "@google-cloud/storage": "^6.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3550,11 +3550,6 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-lru-cache@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.1.tgz#0a3be479df549cca0e5d693ac402ff19537a6b7a"
-  integrity sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==
-
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"


### PR DESCRIPTION
Fixes: #83 

## Motivation and Context
`lru-cache` is an unused dependency. 

## Description
`lru-cache` has been removed using `yarn remove`.

## How has this been tested?
This change has not been manually tested as it is not expected to change any functionality.
