### PR TITLE
chore(deps): Bump common sdk version to match js-client-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Eppo-exp/node-server-sdk#readme",
   "dependencies": {
-    "@eppo/js-client-sdk-common": "4.8.0-alpha.1"
+    "@eppo/js-client-sdk-common": "4.8.1"
   },
   "devDependencies": {
     "@google-cloud/storage": "^6.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "3.7.0-alpha.0",
+  "version": "3.7.0",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,10 +460,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eppo/js-client-sdk-common@4.8.0-alpha.1":
-  version "4.8.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.8.0-alpha.1.tgz#3c5c5f9fad5aa4ba582f0f9ea09b5ee60456e4cf"
-  integrity sha512-sB/3D/aj4TvTw44mxb2hWNGB22FrJzvHrQxQ6eGGeTBZkrBJz4wnl3WcvVjiiNPKBJpKxYGs5C0kM/++IHfH6A==
+"@eppo/js-client-sdk-common@4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.8.1.tgz#d273a43e791e50d36aea4dd8813e406139464e10"
+  integrity sha512-z++Z3XxTUAcjYyt63YYN5mkzsBy25LYI1BU3hj3uKl6sn6hHqXJLftQcU/8n/b7VZgL8XTTD2+85xzKbCMKdAA==
   dependencies:
     buffer "npm:@eppo/buffer@6.2.0"
     js-base64 "^3.7.7"


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
See https://github.com/Eppo-exp/js-client-sdk/pull/146 for context

## Description
Bump js-client-sdk-common to `v4.8.1`

## How has this been tested?
CI


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
