### PR TITLE
fix(events): Allow disabling event logging, check r/o FS

### DIFF
--- a/src/i-client-config.ts
+++ b/src/i-client-config.ts
@@ -48,23 +48,23 @@ export interface IClientConfig {
 
   /** Configuration settings for the event dispatcher */
   eventIngestionConfig?: {
-    /** Whether to disable event ingestion. Defaults to false. */
-    disabled?: boolean;
-    /** Number of milliseconds to wait between each batch delivery. Defaults to 10 seconds. */
-    deliveryIntervalMs?: number;
-    /** Minimum amount of milliseconds to wait before retrying a failed delivery. Defaults to 5 seconds */
-    retryIntervalMs?: number;
-    /** Maximum amount of milliseconds to wait before retrying a failed delivery. Defaults to 30 seconds. */
-    maxRetryDelayMs?: number;
-    /** Maximum number of retry attempts before giving up on a batch delivery. Defaults to 3 retries. */
-    maxRetries?: number;
     /** Maximum number of events to send per delivery request. Defaults to 1000 events. */
     batchSize?: number;
+    /** Number of milliseconds to wait between each batch delivery. Defaults to 10 seconds. */
+    deliveryIntervalMs?: number;
+    /** Whether to disable event ingestion. Defaults to false. */
+    disabled?: boolean;
     /**
      * Maximum number of events to queue in memory before starting to drop events.
      * Note: This is only used if localStorage is not available.
      * Defaults to 10000 events.
      */
     maxQueueSize?: number;
+    /** Maximum number of retry attempts before giving up on a batch delivery. Defaults to 3 retries. */
+    maxRetries?: number;
+    /** Maximum amount of milliseconds to wait before retrying a failed delivery. Defaults to 30 seconds. */
+    maxRetryDelayMs?: number;
+    /** Minimum amount of milliseconds to wait before retrying a failed delivery. Defaults to 5 seconds */
+    retryIntervalMs?: number;
   };
 }

--- a/src/i-client-config.ts
+++ b/src/i-client-config.ts
@@ -45,4 +45,26 @@ export interface IClientConfig {
 
   /** Amount of time in milliseconds to wait between API calls to refresh configuration data. Default of 30_000 (30s). */
   pollingIntervalMs?: number;
+
+  /** Configuration settings for the event dispatcher */
+  eventIngestionConfig?: {
+    /** Whether to disable event ingestion. Defaults to false. */
+    disabled?: boolean;
+    /** Number of milliseconds to wait between each batch delivery. Defaults to 10 seconds. */
+    deliveryIntervalMs?: number;
+    /** Minimum amount of milliseconds to wait before retrying a failed delivery. Defaults to 5 seconds */
+    retryIntervalMs?: number;
+    /** Maximum amount of milliseconds to wait before retrying a failed delivery. Defaults to 30 seconds. */
+    maxRetryDelayMs?: number;
+    /** Maximum number of retry attempts before giving up on a batch delivery. Defaults to 3 retries. */
+    maxRetries?: number;
+    /** Maximum number of events to send per delivery request. Defaults to 1000 events. */
+    batchSize?: number;
+    /**
+     * Maximum number of events to queue in memory before starting to drop events.
+     * Note: This is only used if localStorage is not available.
+     * Defaults to 10000 events.
+     */
+    maxQueueSize?: number;
+  };
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -14,7 +14,6 @@ import {
   decodePrecomputedFlag,
   BanditParameters,
   BanditVariation,
-  applicationLogger,
 } from '@eppo/js-client-sdk-common';
 import * as base64 from 'js-base64';
 import * as td from 'testdouble';

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,11 +150,11 @@ function newEventDispatcher(
   const {
     batchSize = 1_000,
     deliveryIntervalMs = 10_000,
-    retryIntervalMs = 5_000,
-    maxRetryDelayMs = 30_000,
-    maxRetries = 3,
-    maxQueueSize = 10_000,
     disabled = false,
+    maxQueueSize = 10_000,
+    maxRetries = 3,
+    maxRetryDelayMs = 30_000,
+    retryIntervalMs = 5_000,
   } = config;
   if (disabled) {
     return NO_OP_EVENT_DISPATCHER;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,17 @@ import {
   BanditActions,
   BanditParameters,
   BanditVariation,
+  BoundedEventQueue,
   ContextAttributes,
   EppoClient,
   Event,
+  EventDispatcher,
   Flag,
   FlagConfigurationRequestParameters,
   FlagKey,
   MemoryOnlyConfigurationStore,
+  NamedEventQueue,
+  applicationLogger,
   newDefaultEventDispatcher,
 } from '@eppo/js-client-sdk-common';
 
@@ -17,6 +21,7 @@ import FileBackedNamedEventQueue from './events/file-backed-named-event-queue';
 import { IClientConfig } from './i-client-config';
 import { sdkName, sdkVersion } from './sdk-data';
 import { generateSalt } from './util';
+import { isReadOnlyFs } from './util/index';
 
 export {
   Attributes,
@@ -35,6 +40,13 @@ export { IClientConfig };
 
 let clientInstance: EppoClient;
 
+export const NO_OP_EVENT_DISPATCHER: EventDispatcher = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  attachContext: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  dispatch: () => {},
+};
+
 /**
  * Initializes the Eppo client with configuration parameters.
  * This method should be called once on application startup.
@@ -52,6 +64,7 @@ export async function init(config: IClientConfig): Promise<EppoClient> {
     pollingIntervalMs,
     throwOnFailedInitialization = true,
     pollAfterFailedInitialization = false,
+    eventIngestionConfig,
   } = config;
   if (!apiKey) {
     throw new Error('API key is required');
@@ -75,7 +88,7 @@ export async function init(config: IClientConfig): Promise<EppoClient> {
   const flagConfigurationStore = new MemoryOnlyConfigurationStore<Flag>();
   const banditVariationConfigurationStore = new MemoryOnlyConfigurationStore<BanditVariation[]>();
   const banditModelConfigurationStore = new MemoryOnlyConfigurationStore<BanditParameters>();
-  const eventDispatcher = newEventDispatcher(apiKey);
+  const eventDispatcher = newEventDispatcher(apiKey, eventIngestionConfig);
 
   clientInstance = new EppoClient({
     flagConfigurationStore,
@@ -130,8 +143,35 @@ export function getInstance(): EppoClient {
   return clientInstance;
 }
 
-function newEventDispatcher(sdkKey: string) {
-  const eventQueue = new FileBackedNamedEventQueue<Event>('events');
+function newEventDispatcher(
+  sdkKey: string,
+  eventIngestionConfig: IClientConfig['eventIngestionConfig'] = {
+    disabled: false,
+  },
+): EventDispatcher {
+  if (eventIngestionConfig.disabled) {
+    return NO_OP_EVENT_DISPATCHER;
+  }
+
+  let eventQueue: NamedEventQueue<Event>;
+  try {
+    // Check if the file system is read-only
+    if (isReadOnlyFs(`${process.cwd()}/.queues`)) {
+      applicationLogger.warn(
+        'File system appears to be read-only. Using in-memory event queue instead.',
+      );
+      eventQueue = new BoundedEventQueue<Event>('events');
+    } else {
+      eventQueue = new FileBackedNamedEventQueue<Event>('events');
+    }
+  } catch (error) {
+    // If there's any error during the check, fall back to BoundedEventQueue
+    applicationLogger.warn(
+      `Error checking file system: ${error}. Using in-memory event queue instead.`,
+    );
+    eventQueue = new BoundedEventQueue<Event>('events');
+  }
+
   const emptyNetworkStatusListener =
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     { isOffline: () => false, onNetworkStatusChange: () => {} };

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,18 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Checks if the file system is read-only by attempting to write to a temporary file.
+ * @param directory The directory to check for write access
+ * @returns True if the file system is read-only, false otherwise
+ */
+export function isReadOnlyFs(directory: string): boolean {
+  try {
+    const testFilePath = path.join(directory, '.write_test_' + Date.now());
+    fs.writeFileSync(testFilePath, 'test', { flag: 'w' });
+    fs.unlinkSync(testFilePath);
+    return false;
+  } catch (error) {
+    return true;
+  }
+}


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
* Allow disabling event ingestion (false by default)
* Check for read-only file system and use in-memory store if so
* Set default values and forward to underlying factory function

## Description
This logic now more closely matches the js-client-sdk implementation https://github.com/Eppo-exp/js-client-sdk/blob/main/src/index.ts#L983-L1004

## How has this been tested?
Wrote tests


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
