### PR TITLE
chore: upgrade js-client-sdk-common to v4.13.2 for non-bandit flags fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Eppo-exp/node-server-sdk#readme",
   "dependencies": {
-    "@eppo/js-client-sdk-common": "4.13.1"
+    "@eppo/js-client-sdk-common": "4.13.2"
   },
   "devDependencies": {
     "@google-cloud/storage": "^6.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/node-server-sdk",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Eppo node server SDK",
   "main": "dist/index.js",
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,10 +460,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eppo/js-client-sdk-common@4.13.1":
-  version "4.13.1"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.13.1.tgz#b46aa0e57cb11cd22b9b159428b6e92e5b36d282"
-  integrity sha512-ToSIZEmtdrTJMzIyVAKU9fajaaOdsCFeY5gL9WMxxMfqt3zWOsXB2MTWhcrf59THb8HaWNuS7TeB8SMwFjv5bQ==
+"@eppo/js-client-sdk-common@4.13.2":
+  version "4.13.2"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.13.2.tgz#0fffcaa350bfdd12e0ceb2925f543cddd22fd0f8"
+  integrity sha512-XEqajWhqONInZWPxr17iFdUjF3kxqVxe9e2hxa8lHtj4G63pdb/t/3kW6awFL8iz/S8MAurqljnh6X0JRSbGdA==
   dependencies:
     buffer "npm:@eppo/buffer@6.2.0"
     js-base64 "^3.7.7"


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

See https://github.com/Eppo-exp/js-sdk-common/pull/238

Also bandit tests are failing in [test-node-sdk (linux) / test-packaged-server-sdks](https://github.com/Eppo-exp/sdk-test-data/actions/runs/13800196605/job/38600886839?pr=124#logs)

It might be a better use of time to look into fixing these tests after the node sdk is updated with the latest approach for getting bandit actions

## Description
[//]: # (Describe your changes in detail)

Just bumps the version and common version.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
