### PR TITLE
Offline Init Part 1 of 4: Add getFlagsConfiguration() to export flag configuration as JSON

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -746,8 +746,16 @@ describe('EppoClient E2E test', () => {
   });
 
   describe('getFlagsConfiguration', () => {
+    let client: EppoClient | null = null;
+
+    afterAll(() => {
+      if (client) {
+        client.stopPolling();
+      }
+    });
+
     it('returns configuration JSON with flags and format after init', async () => {
-      const client = await init({
+      client = await init({
         apiKey: 'dummy',
         baseUrl: `http://127.0.0.1:${TEST_SERVER_PORT}`,
         assignmentLogger: { logAssignment: jest.fn() },
@@ -765,8 +773,6 @@ describe('EppoClient E2E test', () => {
       if (parsed.environment) {
         expect(parsed.environment.name).toBeDefined();
       }
-
-      client.stopPolling();
     });
   });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -32,7 +32,14 @@ import {
 
 import * as util from './util/index';
 
-import { getInstance, IAssignmentEvent, IAssignmentLogger, init, NO_OP_EVENT_DISPATCHER } from '.';
+import {
+  getFlagsConfiguration,
+  getInstance,
+  IAssignmentEvent,
+  IAssignmentLogger,
+  init,
+  NO_OP_EVENT_DISPATCHER,
+} from '.';
 
 import SpyInstance = jest.SpyInstance;
 
@@ -734,5 +741,55 @@ describe('EppoClient E2E test', () => {
       const configurationRequestParameters = client['configurationRequestParameters'];
       expect(configurationRequestParameters.pollAfterSuccessfulInitialization).toBe(false);
     });
+  });
+});
+
+describe('getFlagsConfiguration', () => {
+  it('returns configuration JSON after init', async () => {
+    await init({
+      apiKey: 'dummy',
+      baseUrl: `http://127.0.0.1:${TEST_SERVER_PORT}`,
+      assignmentLogger: { logAssignment: jest.fn() },
+    });
+
+    const exportedConfig = getFlagsConfiguration();
+    expect(exportedConfig).not.toBeNull();
+
+    const parsed = JSON.parse(exportedConfig ?? '');
+    expect(parsed.flags).toBeDefined();
+    expect(parsed.format).toBe('SERVER');
+  });
+
+  it('includes flags from the API response', async () => {
+    await init({
+      apiKey: 'dummy',
+      baseUrl: `http://127.0.0.1:${TEST_SERVER_PORT}`,
+      assignmentLogger: { logAssignment: jest.fn() },
+    });
+
+    const exportedConfig = getFlagsConfiguration();
+    expect(exportedConfig).not.toBeNull();
+
+    const parsed = JSON.parse(exportedConfig ?? '');
+    // The mock server returns flags, so we should have some
+    expect(Object.keys(parsed.flags).length).toBeGreaterThan(0);
+  });
+
+  it('includes environment when available', async () => {
+    await init({
+      apiKey: 'dummy',
+      baseUrl: `http://127.0.0.1:${TEST_SERVER_PORT}`,
+      assignmentLogger: { logAssignment: jest.fn() },
+    });
+
+    const exportedConfig = getFlagsConfiguration();
+    expect(exportedConfig).not.toBeNull();
+
+    const parsed = JSON.parse(exportedConfig ?? '');
+    // Environment may or may not be set depending on mock data
+    // Just verify the structure is correct
+    if (parsed.environment) {
+      expect(parsed.environment.name).toBeDefined();
+    }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,10 @@ let banditModelConfigurationStore: MemoryOnlyConfigurationStore<BanditParameters
 
 /**
  * Represents a bandit reference linking a bandit to its flag variations.
- * Matches the BanditReference interface from the common package.
+ *
+ * TODO: Remove this local definition once BanditReference is exported from @eppo/js-client-sdk-common.
+ * This duplicates the BanditReference interface from the common package's http-client module,
+ * which is not currently exported from the package's public API.
  */
 interface BanditReference {
   modelVersion: string;
@@ -62,8 +65,10 @@ interface BanditReference {
 
 /**
  * Represents the universal flag configuration response format.
- * This matches the IUniversalFlagConfigResponse interface from the common package's http-client.
- * All fields are required - validation ensures they exist before use.
+ *
+ * TODO: Remove this local definition once IUniversalFlagConfigResponse is exported from @eppo/js-client-sdk-common.
+ * This duplicates the IUniversalFlagConfigResponse interface from the common package's http-client module,
+ * which is not currently exported from the package's public API.
  */
 interface FlagsConfigurationResponse {
   createdAt: string;
@@ -191,9 +196,9 @@ export function getFlagsConfiguration(): string | null {
   // Build configuration matching FlagsConfigurationResponse structure.
   // All fields are required - they are guaranteed to exist after successful initialization.
   const configuration: FlagsConfigurationResponse = {
-    createdAt: flagConfigurationStore.getConfigPublishedAt() ?? '',
+    createdAt: flagConfigurationStore.getConfigPublishedAt() ?? new Date().toISOString(),
     format: flagConfigurationStore.getFormat() ?? FormatEnum.SERVER,
-    environment: flagConfigurationStore.getEnvironment() ?? { name: '' },
+    environment: flagConfigurationStore.getEnvironment() ?? { name: 'UNKNOWN' },
     flags: flagConfigurationStore.entries(),
     banditReferences: reconstructBanditReferences(),
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,11 @@ export {
 export { IClientConfig };
 
 let clientInstance: EppoClient;
+
+// We keep references to the configuration stores at module level because EppoClient
+// does not expose public getters for store metadata (format, createdAt, environment)
+// or bandit configurations. These references are needed by getFlagsConfiguration()
+// and getBanditsConfiguration() to reconstruct exportable configuration JSON.
 let flagConfigurationStore: MemoryOnlyConfigurationStore<Flag>;
 let banditVariationConfigurationStore: MemoryOnlyConfigurationStore<BanditVariation[]>;
 let banditModelConfigurationStore: MemoryOnlyConfigurationStore<BanditParameters>;
@@ -148,7 +153,7 @@ export function getInstance(): EppoClient {
 }
 
 /**
- * Returns the current flags configuration as a JSON string.
+ * Reconstructs the current flags configuration as a JSON string.
  * This can be used to bootstrap another SDK instance using offlineInit().
  *
  * @returns JSON string containing the flags configuration, or null if not initialized


### PR DESCRIPTION
## Summary
- Adds `getFlagsConfiguration()` function to export the current flags configuration as JSON
- This enables bootstrapping other SDK instances via offline initialization

## Stacked PRs
- 👉 Part 1: `getFlagsConfiguration()` (this PR)
- 🔲 [Part 2: `getBanditsConfiguration()`](https://github.com/Eppo-exp/node-server-sdk/pull/117)
- 🔲 [Part 3: `offlineInit()`](https://github.com/Eppo-exp/node-server-sdk/pull/118)
- 🔲 [Part 4: Shared round-trip tests](https://github.com/Eppo-exp/node-server-sdk/pull/119)

## Test plan
- Verify `getFlagsConfiguration()` returns null before initialization
- Verify it returns valid JSON with flags and format after init
- Verify the exported configuration matches the expected structure from flags-v1.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)