### PR TITLE
Offline Init Part 2 of 4: Add getBanditsConfiguration() to export bandit models as JSON

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -6,7 +6,7 @@ env:
 
 on:
   pull_request:
-    branches: [ "*" ]
+    branches: [ "**" ]
   workflow_dispatch:
   workflow_call:
     inputs:

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -837,16 +837,20 @@ describe('EppoClient E2E test', () => {
   });
 
   describe('getBanditsConfiguration', () => {
-    it('returns null when no bandits are configured', async () => {
+    it('returns empty bandits configuration when no bandits are configured', async () => {
       await init({
         apiKey: 'dummy',
         baseUrl: `http://127.0.0.1:${TEST_SERVER_PORT}`,
         assignmentLogger: { logAssignment: jest.fn() },
       });
 
-      // The default mock doesn't include bandits, so this should return null
+      // The default mock doesn't include bandits, so this should return an empty bandits map
       const banditsConfig = getBanditsConfiguration();
-      expect(banditsConfig).toBeNull();
+      expect(banditsConfig).not.toBeNull();
+      expect(banditsConfig).toBeDefined();
+      const parsed = JSON.parse(banditsConfig as string);
+      expect(parsed.bandits).toEqual({});
+      expect(parsed.updatedAt).toBeDefined();
     });
 
     it('returns bandits configuration JSON matching bandit-models-v1.json structure', async () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -33,6 +33,7 @@ import {
 import * as util from './util/index';
 
 import {
+  getBanditsConfiguration,
   getFlagsConfiguration,
   getInstance,
   IAssignmentEvent,
@@ -833,5 +834,36 @@ describe('EppoClient E2E test', () => {
         owner: 'hippo',
       });
     });
+  });
+});
+
+describe('getBanditsConfiguration', () => {
+  it('returns null when no bandits are configured', async () => {
+    await init({
+      apiKey: 'dummy',
+      baseUrl: `http://127.0.0.1:${TEST_SERVER_PORT}`,
+      assignmentLogger: { logAssignment: jest.fn() },
+    });
+
+    // The default mock doesn't include bandits, so this should return null
+    const banditsConfig = getBanditsConfiguration();
+    expect(banditsConfig).toBeNull();
+  });
+
+  it('returns bandits configuration JSON when bandits are present', async () => {
+    await init({
+      apiKey: TEST_BANDIT_API_KEY,
+      baseUrl: `http://127.0.0.1:${TEST_SERVER_PORT}`,
+      assignmentLogger: { logAssignment: jest.fn() },
+      banditLogger: { logBanditAction: jest.fn() },
+    });
+
+    const banditsConfig = getBanditsConfiguration();
+    // With the bandit API key, we should have bandits
+    if (banditsConfig) {
+      const parsed = JSON.parse(banditsConfig);
+      expect(parsed.bandits).toBeDefined();
+      expect(Object.keys(parsed.bandits).length).toBeGreaterThan(0);
+    }
   });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -835,35 +835,35 @@ describe('EppoClient E2E test', () => {
       });
     });
   });
-});
 
-describe('getBanditsConfiguration', () => {
-  it('returns null when no bandits are configured', async () => {
-    await init({
-      apiKey: 'dummy',
-      baseUrl: `http://127.0.0.1:${TEST_SERVER_PORT}`,
-      assignmentLogger: { logAssignment: jest.fn() },
+  describe('getBanditsConfiguration', () => {
+    it('returns null when no bandits are configured', async () => {
+      await init({
+        apiKey: 'dummy',
+        baseUrl: `http://127.0.0.1:${TEST_SERVER_PORT}`,
+        assignmentLogger: { logAssignment: jest.fn() },
+      });
+
+      // The default mock doesn't include bandits, so this should return null
+      const banditsConfig = getBanditsConfiguration();
+      expect(banditsConfig).toBeNull();
     });
 
-    // The default mock doesn't include bandits, so this should return null
-    const banditsConfig = getBanditsConfiguration();
-    expect(banditsConfig).toBeNull();
-  });
+    it('returns bandits configuration JSON when bandits are present', async () => {
+      await init({
+        apiKey: TEST_BANDIT_API_KEY,
+        baseUrl: `http://127.0.0.1:${TEST_SERVER_PORT}`,
+        assignmentLogger: { logAssignment: jest.fn() },
+        banditLogger: { logBanditAction: jest.fn() },
+      });
 
-  it('returns bandits configuration JSON when bandits are present', async () => {
-    await init({
-      apiKey: TEST_BANDIT_API_KEY,
-      baseUrl: `http://127.0.0.1:${TEST_SERVER_PORT}`,
-      assignmentLogger: { logAssignment: jest.fn() },
-      banditLogger: { logBanditAction: jest.fn() },
+      const banditsConfig = getBanditsConfiguration();
+      // With the bandit API key, we should have bandits
+      if (banditsConfig) {
+        const parsed = JSON.parse(banditsConfig);
+        expect(parsed.bandits).toBeDefined();
+        expect(Object.keys(parsed.bandits).length).toBeGreaterThan(0);
+      }
     });
-
-    const banditsConfig = getBanditsConfiguration();
-    // With the bandit API key, we should have bandits
-    if (banditsConfig) {
-      const parsed = JSON.parse(banditsConfig);
-      expect(parsed.bandits).toBeDefined();
-      expect(Object.keys(parsed.bandits).length).toBeGreaterThan(0);
-    }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,11 +80,13 @@ interface FlagsConfigurationResponse {
 
 /**
  * Represents the bandits configuration response format.
- * This matches the IBanditParametersResponse interface from the common package's http-client,
- * except updatedAt is optional since we don't store it separately.
+ *
+ * TODO: Remove this local definition once IBanditParametersResponse is exported from @eppo/js-client-sdk-common.
+ * This duplicates the IBanditParametersResponse interface from the common package's http-client module,
+ * which is not currently exported from the package's public API.
  */
 interface BanditsConfigurationResponse {
-  updatedAt?: string;
+  updatedAt: string;
   bandits: Record<string, BanditParameters>;
 }
 
@@ -261,25 +263,14 @@ function reconstructBanditReferences(): Record<string, BanditReference> {
  * This can be used together with getFlagsConfiguration() to bootstrap
  * another SDK instance using offlineInit().
  *
- * @returns JSON string containing the bandits configuration, or null if not initialized or no bandits
+ * @returns JSON string containing the bandits configuration
  * @public
  */
-export function getBanditsConfiguration(): string | null {
-  if (!banditModelConfigurationStore) {
-    return null;
-  }
-
-  const bandits = banditModelConfigurationStore.entries();
-
-  // Return null if there are no bandits
-  if (Object.keys(bandits).length === 0) {
-    return null;
-  }
-
+export function getBanditsConfiguration(): string {
   // Build configuration matching BanditsConfigurationResponse structure.
-  // Note: updatedAt is not available from the store, so it's omitted.
   const configuration: BanditsConfigurationResponse = {
-    bandits,
+    updatedAt: new Date().toISOString(), // TODO: ideally we can track this and use it when regenerating bandits configuration
+    bandits: banditModelConfigurationStore ? banditModelConfigurationStore.entries() : {},
   };
 
   return JSON.stringify(configuration);

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,16 @@ interface FlagsConfigurationResponse {
   banditReferences: Record<string, BanditReference>;
 }
 
+/**
+ * Represents the bandits configuration response format.
+ * This matches the IBanditParametersResponse interface from the common package's http-client,
+ * except updatedAt is optional since we don't store it separately.
+ */
+interface BanditsConfigurationResponse {
+  updatedAt?: string;
+  bandits: Record<string, BanditParameters>;
+}
+
 export const NO_OP_EVENT_DISPATCHER: EventDispatcher = {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   attachContext: () => {},
@@ -266,9 +276,9 @@ export function getBanditsConfiguration(): string | null {
     return null;
   }
 
-  const configuration: {
-    bandits: Record<string, BanditParameters>;
-  } = {
+  // Build configuration matching BanditsConfigurationResponse structure.
+  // Note: updatedAt is not available from the store, so it's omitted.
+  const configuration: BanditsConfigurationResponse = {
     bandits,
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,35 @@ function reconstructBanditReferences(): Record<string, BanditReference> {
   return banditReferences;
 }
 
+/**
+ * Returns the current bandits configuration as a JSON string.
+ * This can be used together with getFlagsConfiguration() to bootstrap
+ * another SDK instance using offlineInit().
+ *
+ * @returns JSON string containing the bandits configuration, or null if not initialized or no bandits
+ * @public
+ */
+export function getBanditsConfiguration(): string | null {
+  if (!banditModelConfigurationStore) {
+    return null;
+  }
+
+  const bandits = banditModelConfigurationStore.entries();
+
+  // Return null if there are no bandits
+  if (Object.keys(bandits).length === 0) {
+    return null;
+  }
+
+  const configuration: {
+    bandits: Record<string, BanditParameters>;
+  } = {
+    bandits,
+  };
+
+  return JSON.stringify(configuration);
+}
+
 function newEventDispatcher(
   sdkKey: string,
   config: IClientConfig['eventTracking'] = {},


### PR DESCRIPTION
## Summary
- Adds `getBanditsConfiguration()` function to export bandit models as JSON
- Complements `getFlagsConfiguration()` for complete offline initialization support

## Stacked PRs
- ☑️ [Part 1: `getFlagsConfiguration()`](https://github.com/Eppo-exp/node-server-sdk/pull/116)
- 👉 Part 2: `getBanditsConfiguration()` (this PR)
- 🔲 [Part 3: `offlineInit()`](https://github.com/Eppo-exp/node-server-sdk/pull/118)
- 🔲 [Part 4: Shared round-trip tests](https://github.com/Eppo-exp/node-server-sdk/pull/119)

## Test plan
- Verify `getBanditsConfiguration()` returns null before initialization
- Verify it returns null when no bandits are configured
- Verify it returns valid JSON with bandit parameters matching bandit-models-v1.json structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)