### PR TITLE
Offline Init Part 3 of 4: Add offlineInit() for synchronous SDK initialization without network

### DIFF
--- a/src/i-client-config.ts
+++ b/src/i-client-config.ts
@@ -52,7 +52,10 @@ export interface IClientConfig {
   /** Amount of time in milliseconds to wait between API calls to refresh configuration data. Default of 30_000 (30s). */
   pollingIntervalMs?: number;
 
-  /** Configuration settings for the event dispatcher */
+  /**
+   * Configuration settings for the event dispatcher.
+   * @deprecated Eppo has discontinued eventing support. Event tracking will be handled by Datadog SDKs.
+   */
   eventTracking?: {
     /** Maximum number of events to send per delivery request. Defaults to 1000 events. */
     batchSize?: number;
@@ -73,4 +76,56 @@ export interface IClientConfig {
     /** Minimum amount of milliseconds to wait before retrying a failed delivery. Defaults to 5 seconds */
     retryIntervalMs?: number;
   };
+}
+
+/**
+ * Configuration used for offline initialization of the Eppo client.
+ * Offline initialization allows the SDK to be used without making any network requests.
+ * @public
+ */
+export interface IOfflineClientConfig {
+  /**
+   * The full flags configuration JSON string as returned by the Eppo API.
+   * This should be the complete response from the /flag-config/v1/config endpoint.
+   *
+   * Expected format:
+   * ```json
+   * {
+   *   "createdAt": "2024-04-17T19:40:53.716Z",
+   *   "format": "SERVER",
+   *   "environment": { "name": "production" },
+   *   "flags": { ... }
+   * }
+   * ```
+   */
+  flagsConfiguration: string;
+
+  /**
+   * Optional bandit models configuration JSON string as returned by the Eppo API.
+   * This should be the complete response from the bandit parameters endpoint.
+   *
+   * Expected format:
+   * ```json
+   * {
+   *   "updatedAt": "2024-04-17T19:40:53.716Z",
+   *   "bandits": { ... }
+   * }
+   * ```
+   */
+  banditsConfiguration?: string;
+
+  /**
+   * Optional assignment logger for sending variation assignments to your data warehouse.
+   * Required for experiment analysis.
+   */
+  assignmentLogger?: IAssignmentLogger;
+
+  /** Optional bandit logger for sending bandit actions to your data warehouse */
+  banditLogger?: IBanditLogger;
+
+  /**
+   * Whether to throw an error if initialization fails. (default: true)
+   * If false, the client will be initialized with an empty configuration.
+   */
+  throwOnFailedInitialization?: boolean;
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -983,13 +983,21 @@ describe('offlineInit', () => {
   // Helper to create a full configuration JSON string
   const createFlagsConfigJson = (
     flags: Record<string, Flag>,
-    options: { createdAt?: string; format?: string } = {},
+    options: {
+      createdAt?: string;
+      format?: string;
+      banditReferences?: Record<
+        string,
+        { modelVersion: string; flagVariations: BanditVariation[] }
+      >;
+    } = {},
   ): string => {
     return JSON.stringify({
       createdAt: options.createdAt ?? '2024-04-17T19:40:53.716Z',
       format: options.format ?? 'SERVER',
       environment: { name: 'Test' },
       flags,
+      banditReferences: options.banditReferences ?? {},
     });
   };
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1027,7 +1027,7 @@ describe('offlineInit', () => {
       expect(assignment).toEqual('default-value');
     });
 
-    it('makes client available via getInstance()', () => {
+    it('can request assignment', () => {
       offlineInit({
         flagsConfiguration: createFlagsConfigJson({ [flagKey]: mockUfcFlagConfig }),
       });
@@ -1035,6 +1035,16 @@ describe('offlineInit', () => {
       const client = getInstance();
       const assignment = client.getStringAssignment(flagKey, 'subject-10', {}, 'default-value');
       expect(assignment).toEqual('variant-1');
+    });
+
+    it('does not have configurationRequestParameters (no polling)', () => {
+      const client = offlineInit({
+        flagsConfiguration: createFlagsConfigJson({ [flagKey]: mockUfcFlagConfig }),
+      });
+
+      // Access the internal configurationRequestParameters - should be undefined for offline mode
+      const configurationRequestParameters = client['configurationRequestParameters'];
+      expect(configurationRequestParameters).toBeUndefined();
     });
   });
 
@@ -1105,23 +1115,12 @@ describe('offlineInit', () => {
     });
 
     it('does not throw with valid empty flags configuration', () => {
-      expect(() => {
-        offlineInit({
-          flagsConfiguration: createFlagsConfigJson({}),
-        });
-      }).not.toThrow();
-    });
-  });
-
-  describe('no network requests', () => {
-    it('does not have configurationRequestParameters (no polling)', () => {
       const client = offlineInit({
-        flagsConfiguration: createFlagsConfigJson({ [flagKey]: mockUfcFlagConfig }),
+        flagsConfiguration: createFlagsConfigJson({}),
       });
 
-      // Access the internal configurationRequestParameters - should be undefined for offline mode
-      const configurationRequestParameters = client['configurationRequestParameters'];
-      expect(configurationRequestParameters).toBeUndefined();
+      const assignment = client.getStringAssignment(flagKey, 'subject-1', {}, 'default-value');
+      expect(assignment).toEqual('default-value');
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,62 +97,6 @@ interface BanditsConfigurationResponse {
 const DEFAULT_ASSIGNMENT_CACHE_SIZE = 50_000;
 
 /**
- * Validates that the parsed flags configuration has all required fields.
- * Returns an array of validation error messages, or empty array if valid.
- */
-function validateFlagsConfiguration(config: unknown): string[] {
-  const errors: string[] = [];
-
-  if (!config || typeof config !== 'object') {
-    errors.push('Configuration must be an object');
-    return errors;
-  }
-
-  const cfg = config as Record<string, unknown>;
-
-  if (typeof cfg.createdAt !== 'string') {
-    errors.push('Missing or invalid "createdAt" field');
-  }
-  if (typeof cfg.format !== 'string') {
-    errors.push('Missing or invalid "format" field');
-  }
-  if (!cfg.environment || typeof cfg.environment !== 'object') {
-    errors.push('Missing or invalid "environment" field');
-  } else if (typeof (cfg.environment as Record<string, unknown>).name !== 'string') {
-    errors.push('Missing or invalid "environment.name" field');
-  }
-  if (!cfg.flags || typeof cfg.flags !== 'object') {
-    errors.push('Missing or invalid "flags" field');
-  }
-  if (!cfg.banditReferences || typeof cfg.banditReferences !== 'object') {
-    errors.push('Missing or invalid "banditReferences" field');
-  }
-
-  return errors;
-}
-
-/**
- * Validates that the parsed bandits configuration has all required fields.
- * Returns an array of validation error messages, or empty array if valid.
- */
-function validateBanditsConfiguration(config: unknown): string[] {
-  const errors: string[] = [];
-
-  if (!config || typeof config !== 'object') {
-    errors.push('Configuration must be an object');
-    return errors;
-  }
-
-  const cfg = config as Record<string, unknown>;
-
-  if (!cfg.bandits || typeof cfg.bandits !== 'object') {
-    errors.push('Missing or invalid "bandits" field');
-  }
-
-  return errors;
-}
-
-/**
  * @deprecated Eppo has discontinued eventing support. Event tracking will be handled by Datadog SDKs.
  */
 export const NO_OP_EVENT_DISPATCHER: EventDispatcher = {
@@ -387,7 +331,11 @@ export function offlineInit(config: IOfflineClientConfig): EppoClient {
       flagConfigurationStore
         .setEntries(flagsConfigResponse.flags)
         .catch((err) =>
-          applicationLogger.warn(`Error setting flags for memory-only configuration store: ${err}`),
+          applicationLogger.warn(
+            `Error setting flags for memory-only configuration store: ${
+              err instanceof Error ? err.message : err
+            }`,
+          ),
         );
 
       // Set configuration timestamp
@@ -412,7 +360,9 @@ export function offlineInit(config: IOfflineClientConfig): EppoClient {
         .setEntries(banditVariationsByFlagKey)
         .catch((err) =>
           applicationLogger.warn(
-            `Error setting bandit variations for memory-only configuration store: ${err}`,
+            `Error setting bandit variations for memory-only configuration store: ${
+              err instanceof Error ? err.message : err
+            }`,
           ),
         );
     }
@@ -437,7 +387,9 @@ export function offlineInit(config: IOfflineClientConfig): EppoClient {
           .setEntries(banditsConfigResponse.bandits)
           .catch((err) =>
             applicationLogger.warn(
-              `Error setting bandit models for memory-only configuration store: ${err}`,
+              `Error setting bandit models for memory-only configuration store: ${
+                err instanceof Error ? err.message : err
+              }`,
             ),
           );
       }
@@ -474,6 +426,62 @@ export function offlineInit(config: IOfflineClientConfig): EppoClient {
     // It will return default values for all assignments
     return clientInstance;
   }
+}
+
+/**
+ * Validates that the parsed flags configuration has all required fields.
+ * Returns an array of validation error messages, or empty array if valid.
+ */
+function validateFlagsConfiguration(config: unknown): string[] {
+  const errors: string[] = [];
+
+  if (!config || typeof config !== 'object') {
+    errors.push('Configuration must be an object');
+    return errors;
+  }
+
+  const cfg = config as Record<string, unknown>;
+
+  if (typeof cfg.createdAt !== 'string') {
+    errors.push('Missing or invalid "createdAt" field');
+  }
+  if (typeof cfg.format !== 'string') {
+    errors.push('Missing or invalid "format" field');
+  }
+  if (!cfg.environment || typeof cfg.environment !== 'object') {
+    errors.push('Missing or invalid "environment" field');
+  } else if (typeof (cfg.environment as Record<string, unknown>).name !== 'string') {
+    errors.push('Missing or invalid "environment.name" field');
+  }
+  if (!cfg.flags || typeof cfg.flags !== 'object') {
+    errors.push('Missing or invalid "flags" field');
+  }
+  if (!cfg.banditReferences || typeof cfg.banditReferences !== 'object') {
+    errors.push('Missing or invalid "banditReferences" field');
+  }
+
+  return errors;
+}
+
+/**
+ * Validates that the parsed bandits configuration has all required fields.
+ * Returns an array of validation error messages, or empty array if valid.
+ */
+function validateBanditsConfiguration(config: unknown): string[] {
+  const errors: string[] = [];
+
+  if (!config || typeof config !== 'object') {
+    errors.push('Configuration must be an object');
+    return errors;
+  }
+
+  const cfg = config as Record<string, unknown>;
+
+  if (!cfg.bandits || typeof cfg.bandits !== 'object') {
+    errors.push('Missing or invalid "bandits" field');
+  }
+
+  return errors;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `offlineInit()` function to initialize the SDK with pre-fetched configuration
- Enables SDK usage in environments without network access or for faster startup

## Stacked PRs
- ☑️ [Part 1: `getFlagsConfiguration()`](https://github.com/Eppo-exp/node-server-sdk/pull/116)
- ☑️ [Part 2: `getBanditsConfiguration()`](https://github.com/Eppo-exp/node-server-sdk/pull/117)
- 👉 Part 3: `offlineInit()` (this PR)
- 🔲 [Part 4: Shared round-trip tests](https://github.com/Eppo-exp/node-server-sdk/pull/119)

## Test plan
- Verify `offlineInit()` initializes the client with provided configuration
- Verify flag assignments work correctly after offline initialization
- Verify `getInstance()` returns the client after offline init

🤖 Generated with [Claude Code](https://claude.com/claude-code)