### PR TITLE
Use node 20 for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '20.x'
       - run: yarn install
       - run: yarn test
 


### PR DESCRIPTION
Since node 20 is now minimum supported version we need to use at least that to publish.